### PR TITLE
Deep children check

### DIFF
--- a/app/src/main/java/com/neo/speaktouch/model/Reader.kt
+++ b/app/src/main/java/com/neo/speaktouch/model/Reader.kt
@@ -152,6 +152,6 @@ class Reader(
             val mustReadCheckable: Boolean
         ) : Level
 
-        object Children : Level
+        data object Children : Level
     }
 }

--- a/app/src/main/java/com/neo/speaktouch/utils/object/NodeValidator.kt
+++ b/app/src/main/java/com/neo/speaktouch/utils/object/NodeValidator.kt
@@ -104,6 +104,8 @@ object NodeValidator {
      */
     fun isReadableAsChild(node: NodeInfo): Boolean {
 
-        return hasContentToRead(node) && !mustFocus(node)
+        if (mustFocus(node)) return false
+
+        return hasContentToRead(node) || hasReadableChild(node)
     }
 }


### PR DESCRIPTION
### Description

The `isReadableAsChild` function was not checking its children recursively. This function is used to find out if a `View` can be read as a child of a `ViewGroup`. Generally this occurs when the `ViewGroup` itself does not have a `contentDescription` or any intrinsic content to be read, the app then loops through its children, but not all children can be read, children that must be read directly (another rule) must not be read. read as children of other elements, I deduced this logic by testing Talkback and Jieshou, but I didn't code it correctly, but now it's corrected..

### Fixed issues

Fixes #67 
Fixes #48 
