### PR TITLE
Add custom checkable support

### DIFF
--- a/app/src/main/java/com/neo/speaktouch/model/Type.kt
+++ b/app/src/main/java/com/neo/speaktouch/model/Type.kt
@@ -46,6 +46,8 @@ sealed class Type {
         object Checkbox : Checkable()
 
         object TextView : Checkable()
+
+        object Custom : Checkable()
     }
 
     object Button : Type()
@@ -95,6 +97,8 @@ sealed class Type {
             // View -> TextView -> Button -> CompoundButton -> CheckBox
             if (className `is` CheckBox::class.java) return Checkable.Checkbox
 
+            if (node.isCheckable) return Checkable.Custom
+
             // View -> TextView -> Button
             if (className `is` android.widget.Button::class.java) return Button
 
@@ -129,4 +133,5 @@ fun Type.toTypeText() = when (this) {
     Type.Checkable.Switch -> Text(R.string.text_switch_type)
     Type.Checkable.Toggle -> Text(R.string.text_toggle_type)
     Type.Checkable.TextView -> null /* don't speak type */
+    Type.Checkable.Custom -> null /* don't speak type */
 }

--- a/app/src/main/java/com/neo/speaktouch/utils/extension/AccessibilityNodeInfo.kt
+++ b/app/src/main/java/com/neo/speaktouch/utils/extension/AccessibilityNodeInfo.kt
@@ -242,5 +242,17 @@ fun AccessibilityNodeInfoCompat.toStateText(
 
             return Text(stateDescription.toString())
         }
+
+        Type.Checkable.Custom -> {
+            if (stateDescription.isNullOrEmpty()) {
+                return if (isChecked) {
+                    Text(R.string.text_selected)
+                } else {
+                    Text(R.string.text_not_selected)
+                }
+            }
+
+            return Text(stateDescription.toString())
+        }
     }
 }

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -34,5 +34,10 @@
     <string name="text_disabled">desativado</string>
     <string name="text_selected">selecionado</string>
 
+    <string name="text_not_selected">não selecionado</string>
+    <string name="text_checked">marcado</string>
+    <string name="text_not_checked">não marcado</string>
+    <string name="text_pressed">pressionado</string>
+    <string name="text_not_pressed">não pressionado</string>
     <string name="speak_touch_activated">Speak Touch Ativado</string>
 </resources>


### PR DESCRIPTION
### Description

Just like Talkback, Speak Touch should read the state of custom checkable.

### Improvements

- Add custom checkable support.

### Fixed issues

- Speak Touch was ignoring custom checkable.
